### PR TITLE
Add simple FastAPI server with /hello route

### DIFF
--- a/frontend_server.py
+++ b/frontend_server.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/hello")
+async def hello():
+    return {"message": "Hello, Valerii! This is your AI Agent speaking."}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- create `frontend_server.py` with a FastAPI app
- add a `/hello` route that returns a greeting

## Testing
- `python frontend_server.py` then `curl http://localhost:8000/hello`

------
https://chatgpt.com/codex/tasks/task_e_68534c06e7088331b9614c426483408a